### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends nginx runit netcat-traditional msmtp-mta && \
     apt-get autoremove -y && \
     apt-get clean && \ 
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/service
 
 COPY assets /
     


### PR DESCRIPTION
docker build works locally but encounters an error in a buildx gitaction at "COPY assets /", see here: https://github.com/docker/buildx/issues/150
-> this is because /etc/service is not empty or a symbolic link
we can fix this by removing /etc/service just before the COPY command as we copy the service folder anyways becuse it is in the assists folder.

this will fix the issue #5: https://github.com/AvesIT/filesender-container/issues/5